### PR TITLE
ci: add text coverage

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,7 +1,7 @@
 const shell = require("shelljs");
 
 module.exports = {
-  istanbulReporter: ["html", "lcov"],
+  istanbulReporter: ["html", "lcov", "text"],
   providerOptions: {
     mnemonic: process.env.MNEMONIC,
   },


### PR DESCRIPTION
This PR will:

- add "text" format to istanbul coverage reporter

Why?

- You can see coverage directly in the console, no need to dig into JSON file.

Proof of Work: https://github.com/glinda93/solidity-template/runs/6875017127?check_suite_focus=true

@sebastiantf 