### PR TITLE
ci: add slither and SARIF action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,3 +43,15 @@ jobs:
           fail_ci_if_error: false
           files: ./coverage/lcov.info
           verbose: true
+
+      - name: Run Slither
+        uses: crytic/slither-action@v0.1.1
+        continue-on-error: true
+        id: slither
+        with:
+          sarif: results.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: ${{ steps.slither.outputs.sarif }}


### PR DESCRIPTION
This PR will:

- add a slither action
- upload SARIF to github

After this PR is merged, there will be code scanning alerts displayed like in this [repository](https://github.com/glinda93/hardhat-typescript-template/security/code-scanning)

Proof of Work: https://github.com/glinda93/solidity-template/runs/6875047850?check_suite_focus=true

@sebastiantf 